### PR TITLE
feat: add in-memory cache to github events

### DIFF
--- a/app/features/providers/github/commands/getUpcomingEvents.ts
+++ b/app/features/providers/github/commands/getUpcomingEvents.ts
@@ -8,26 +8,25 @@ import {
 } from '~/features/providers/misc/http'
 import type { Event } from './types'
 import { mapIssuesToEvents } from './misc/mapIssueToEvent'
-import { cache } from './misc/cache'
+import { fetchCached } from './misc/cache'
 
 export const getUpcomingEvents = async (
   nextToken?: String
 ): Promise<ApiResponse<Event[]>> => {
   try {
-    if (cache.has('upcomingEvents')) {
-      return newSuccessfulResponse(cache.get('upcomingEvents'))
-    }
-
     const client = newGraphQLClientFactory()
-    const res = await client<GetUpcomingEventsQuery>(getUpcomingEventsQuery, {
-      owner: 'cyprus-developer-community',
-      repo: 'events',
-      size: 20,
-      after: nextToken
-    })
 
-    const events = await mapIssuesToEvents(res.repository.issues.nodes)
-    cache.set('upcomingEvents', events, 60 * 60 * 24)
+    const cacheKey = 'upcomingEvents'
+    const events = await fetchCached(cacheKey, async () => {
+      const res = await client<GetUpcomingEventsQuery>(getUpcomingEventsQuery, {
+        owner: 'cyprus-developer-community',
+        repo: 'events',
+        size: 20,
+        after: nextToken
+      })
+
+      return mapIssuesToEvents(res.repository.issues.nodes)
+    })
     return newSuccessfulResponse(events)
   } catch (e) {
     return newErrorResponse(e)

--- a/app/features/providers/github/commands/misc/cache.ts
+++ b/app/features/providers/github/commands/misc/cache.ts
@@ -1,0 +1,17 @@
+import NodeCache from 'node-cache'
+let cache: NodeCache
+
+declare global {
+  var __cache: NodeCache | undefined
+}
+
+if (process.env.NODE_ENV === 'production') {
+  cache = new NodeCache()
+} else {
+  if (!global.__cache) {
+    global.__cache = new NodeCache()
+  }
+  cache = global.__cache
+}
+
+export { cache }

--- a/app/features/providers/github/commands/misc/cache.ts
+++ b/app/features/providers/github/commands/misc/cache.ts
@@ -28,7 +28,7 @@ cache.on('expired', (key) => {
 const fetchCached = async <T>(
   cacheKey: string,
   fetcher: () => Promise<T>,
-  ttl = 60 * 60 * 24
+  ttl = 60 * 5
 ) => {
   let response: T
   if (cache.has(cacheKey)) {

--- a/app/features/providers/github/commands/misc/cache.ts
+++ b/app/features/providers/github/commands/misc/cache.ts
@@ -28,7 +28,7 @@ cache.on('expired', (key) => {
 const fetchCached = async <T>(
   cacheKey: string,
   fetcher: () => Promise<T>,
-  ttl = 60 * 5
+  ttl = 60 * 20
 ) => {
   let response: T
   if (cache.has(cacheKey)) {

--- a/app/features/providers/github/commands/misc/cache.ts
+++ b/app/features/providers/github/commands/misc/cache.ts
@@ -1,17 +1,49 @@
 import NodeCache from 'node-cache'
+
 let cache: NodeCache
+let expired = {}
 
 declare global {
   var __cache: NodeCache | undefined
+  var __expired: { [key: string]: boolean }
 }
 
 if (process.env.NODE_ENV === 'production') {
-  cache = new NodeCache()
+  cache = new NodeCache({ deleteOnExpire: false })
 } else {
   if (!global.__cache) {
-    global.__cache = new NodeCache()
+    global.__cache = new NodeCache({ deleteOnExpire: false })
   }
   cache = global.__cache
+  if (!global.__expired) {
+    global.__expired = {}
+  }
+  expired = global.__expired
 }
 
-export { cache }
+cache.on('expired', (key) => {
+  expired[key] = true
+})
+
+const fetchCached = async <T>(
+  cacheKey: string,
+  fetcher: () => Promise<T>,
+  ttl = 60 * 60 * 24
+) => {
+  let response: T
+  if (cache.has(cacheKey)) {
+    response = cache.get(cacheKey)
+    if (expired[cacheKey]) {
+      ;(async () => {
+        expired[cacheKey] = false
+        cache.set(cacheKey, await fetcher(), ttl)
+      })()
+    }
+    return response
+  }
+  response = await fetcher()
+  cache.set(cacheKey, response, ttl)
+  return response
+}
+
+export { cache, fetchCached }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "date-fns-tz": "^2.0.0",
     "graphql": "^16.6.0",
     "marked": "^4.2.12",
+    "node-cache": "^5.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@headlessui/react':
     specifier: ^1.7.12
@@ -47,6 +43,9 @@ dependencies:
   marked:
     specifier: ^4.2.12
     version: 4.2.12
+  node-cache:
+    specifier: ^5.1.2
+    version: 5.1.2
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -828,6 +827,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-import-assertions@7.20.0:
+    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2730,7 +2738,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/parser': 7.21.4
-      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.21.4)
+      '@babel/plugin-syntax-import-assertions': 7.20.0
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.4
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
@@ -5260,6 +5268,11 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
     dev: true
+
+  /clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+    dev: false
 
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -9494,6 +9507,13 @@ packages:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
     dev: true
 
+  /node-cache@5.1.2:
+    resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      clone: 2.1.2
+    dev: false
+
   /node-fetch-native@1.1.0:
     resolution: {integrity: sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==}
     dev: true
@@ -12574,3 +12594,7 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Problem: fetching github events can be very slow (especially when fetching the events index page). 
I'm getting more than 20s in some cases, sometimes it never loads

This PR adds a simple node-cache in memory so that we have the latest data updated every 5m.

The cache returns the old value on the first hit after 5m - and then refresh the cached value, so that the next call will have a fresh value without having to wait for the call